### PR TITLE
Chore: change module name (Mash dump files)

### DIFF
--- a/internal/convert/computed_optional_required.go
+++ b/internal/convert/computed_optional_required.go
@@ -6,7 +6,7 @@ package convert
 import (
 	"bytes"
 
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 )
 
 type ComputedOptionalRequired struct {

--- a/internal/convert/custom_type_collection.go
+++ b/internal/convert/custom_type_collection.go
@@ -6,8 +6,8 @@ package convert
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/format"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"

--- a/internal/convert/custom_type_nested_collection.go
+++ b/internal/convert/custom_type_nested_collection.go
@@ -6,8 +6,8 @@ package convert
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"
 )

--- a/internal/convert/custom_type_nested_object.go
+++ b/internal/convert/custom_type_nested_object.go
@@ -6,8 +6,8 @@ package convert
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/format"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"

--- a/internal/convert/custom_type_object.go
+++ b/internal/convert/custom_type_object.go
@@ -6,8 +6,8 @@ package convert
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/format"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"

--- a/internal/convert/custom_type_primitive.go
+++ b/internal/convert/custom_type_primitive.go
@@ -6,8 +6,8 @@ package convert
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/format"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"

--- a/internal/convert/default_bool.go
+++ b/internal/convert/default_bool.go
@@ -6,8 +6,8 @@ package convert
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	generatorschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"
 )

--- a/internal/convert/default_custom.go
+++ b/internal/convert/default_custom.go
@@ -6,7 +6,7 @@ package convert
 import (
 	"fmt"
 
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	generatorschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"
 )

--- a/internal/convert/default_float64.go
+++ b/internal/convert/default_float64.go
@@ -6,8 +6,8 @@ package convert
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	generatorschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"
 )

--- a/internal/convert/default_int32.go
+++ b/internal/convert/default_int32.go
@@ -1,0 +1,69 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package convert
+
+import (
+	"fmt"
+
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
+
+	generatorschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"
+)
+
+const defaultInt32Import = "github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
+
+type DefaultInt32 struct {
+	int32Default *specschema.Int32Default
+}
+
+func NewDefaultInt32(b *specschema.Int32Default) DefaultInt32 {
+	return DefaultInt32{
+		int32Default: b,
+	}
+}
+
+func (d DefaultInt32) Equal(other DefaultInt32) bool {
+	return d.int32Default.Equal(other.int32Default)
+}
+
+func (d DefaultInt32) Imports() *generatorschema.Imports {
+	imports := generatorschema.NewImports()
+
+	if d.int32Default == nil {
+		return imports
+	}
+
+	if d.int32Default.Static != nil {
+		imports.Add(code.Import{
+			Path: defaultInt32Import,
+		})
+	}
+
+	if d.int32Default.Custom != nil {
+		for _, i := range d.int32Default.Custom.Imports {
+			if len(i.Path) > 0 {
+				imports.Add(i)
+			}
+		}
+	}
+
+	return imports
+}
+
+func (d DefaultInt32) Schema() []byte {
+	if d.int32Default == nil {
+		return nil
+	}
+
+	if d.int32Default.Static != nil {
+		return []byte(fmt.Sprintf("Default: int32default.StaticInt32(%d),\n", *d.int32Default.Static))
+	}
+
+	if d.int32Default.Custom != nil && d.int32Default.Custom.SchemaDefinition != "" {
+		return []byte(fmt.Sprintf("Default: %s,\n", d.int32Default.Custom.SchemaDefinition))
+	}
+
+	return nil
+}

--- a/internal/convert/default_int64.go
+++ b/internal/convert/default_int64.go
@@ -6,8 +6,8 @@ package convert
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	generatorschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"
 )

--- a/internal/convert/default_string.go
+++ b/internal/convert/default_string.go
@@ -6,8 +6,8 @@ package convert
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	generatorschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"
 )

--- a/internal/convert/element_type.go
+++ b/internal/convert/element_type.go
@@ -7,8 +7,8 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"
 )

--- a/internal/convert/nested_attribute_object.go
+++ b/internal/convert/nested_attribute_object.go
@@ -6,7 +6,7 @@ package convert
 import (
 	"bytes"
 
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"
 )

--- a/internal/convert/nested_block_object.go
+++ b/internal/convert/nested_block_object.go
@@ -6,7 +6,7 @@ package convert
 import (
 	"bytes"
 
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"
 )

--- a/internal/convert/object_attribute_types.go
+++ b/internal/convert/object_attribute_types.go
@@ -7,8 +7,8 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"
 )

--- a/internal/convert/optional_required.go
+++ b/internal/convert/optional_required.go
@@ -6,7 +6,7 @@ package convert
 import (
 	"bytes"
 
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 )
 
 type OptionalRequired struct {

--- a/internal/convert/plan_modifiers.go
+++ b/internal/convert/plan_modifiers.go
@@ -7,8 +7,8 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"
 )
@@ -17,6 +17,7 @@ const (
 	PlanModifierTypeBool    PlanModifierType = "Bool"
 	PlanModifierTypeFloat64 PlanModifierType = "Float64"
 	PlanModifierTypeInt64   PlanModifierType = "Int64"
+	PlanModifierTypeInt32   PlanModifierType = "Int32"
 	PlanModifierTypeList    PlanModifierType = "List"
 	PlanModifierTypeMap     PlanModifierType = "Map"
 	PlanModifierTypeNumber  PlanModifierType = "Number"

--- a/internal/convert/validators.go
+++ b/internal/convert/validators.go
@@ -7,8 +7,8 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"
 )
@@ -17,6 +17,7 @@ const (
 	ValidatorTypeBool    ValidatorType = "Bool"
 	ValidatorTypeFloat64 ValidatorType = "Float64"
 	ValidatorTypeInt64   ValidatorType = "Int64"
+	ValidatorTypeInt32   ValidatorType = "Int32"
 	ValidatorTypeList    ValidatorType = "List"
 	ValidatorTypeMap     ValidatorType = "Map"
 	ValidatorTypeNumber  ValidatorType = "Number"

--- a/internal/datasource/bool_attribute.go
+++ b/internal/datasource/bool_attribute.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/bool_attribute_test.go
+++ b/internal/datasource/bool_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/convert.go
+++ b/internal/datasource/convert.go
@@ -6,8 +6,8 @@ package datasource
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/spec"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/spec"
 
 	generatorschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"
 )
@@ -90,6 +90,8 @@ func NewAttribute(a datasource.Attribute) (generatorschema.GeneratorAttribute, e
 		return NewGeneratorFloat64Attribute(a.Name, a.Float64)
 	case a.Int64 != nil:
 		return NewGeneratorInt64Attribute(a.Name, a.Int64)
+	case a.Int32 != nil:
+		return NewGeneratorInt32Attribute(a.Name, a.Int32)
 	case a.List != nil:
 		return NewGeneratorListAttribute(a.Name, a.List)
 	case a.ListNested != nil:

--- a/internal/datasource/convert_test.go
+++ b/internal/datasource/convert_test.go
@@ -6,10 +6,10 @@ package datasource
 import (
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/spec"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/spec"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	generatorschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"

--- a/internal/datasource/float64_attribute.go
+++ b/internal/datasource/float64_attribute.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/float64_attribute_test.go
+++ b/internal/datasource/float64_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/int32_attribute.go
+++ b/internal/datasource/int32_attribute.go
@@ -1,0 +1,226 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package datasource
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
+
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"
+)
+
+type GeneratorInt32Attribute struct {
+	AssociatedExternalType   *schema.AssocExtType
+	ComputedOptionalRequired convert.ComputedOptionalRequired
+	CustomType               convert.CustomTypePrimitive
+	DeprecationMessage       convert.DeprecationMessage
+	Description              convert.Description
+	Sensitive                convert.Sensitive
+	Validators               convert.Validators
+}
+
+func NewGeneratorInt32Attribute(name string, a *datasource.Int32Attribute) (GeneratorInt32Attribute, error) {
+	if a == nil {
+		return GeneratorInt32Attribute{}, fmt.Errorf("*datasource.Int32Attribute is nil")
+	}
+
+	c := convert.NewComputedOptionalRequired(a.ComputedOptionalRequired)
+
+	ctp := convert.NewCustomTypePrimitive(a.CustomType, a.AssociatedExternalType, name)
+
+	d := convert.NewDescription(a.Description)
+
+	dm := convert.NewDeprecationMessage(a.DeprecationMessage)
+
+	s := convert.NewSensitive(a.Sensitive)
+
+	v := convert.NewValidators(convert.ValidatorTypeInt32, a.Validators.CustomValidators())
+
+	return GeneratorInt32Attribute{
+		AssociatedExternalType:   schema.NewAssocExtType(a.AssociatedExternalType),
+		ComputedOptionalRequired: c,
+		CustomType:               ctp,
+		DeprecationMessage:       dm,
+		Description:              d,
+		Sensitive:                s,
+		Validators:               v,
+	}, nil
+}
+
+func (g GeneratorInt32Attribute) GeneratorSchemaType() schema.Type {
+	return schema.GeneratorInt32Attribute
+}
+
+func (g GeneratorInt32Attribute) Imports() *schema.Imports {
+	imports := schema.NewImports()
+
+	imports.Append(g.CustomType.Imports())
+
+	imports.Append(g.Validators.Imports())
+
+	if g.AssociatedExternalType != nil {
+		imports.Append(schema.AssociatedExternalTypeImports())
+	}
+
+	imports.Append(g.AssociatedExternalType.Imports())
+
+	return imports
+}
+
+func (g GeneratorInt32Attribute) Equal(ga schema.GeneratorAttribute) bool {
+	h, ok := ga.(GeneratorInt32Attribute)
+
+	if !ok {
+		return false
+	}
+
+	if !g.AssociatedExternalType.Equal(h.AssociatedExternalType) {
+		return false
+	}
+
+	if !g.ComputedOptionalRequired.Equal(h.ComputedOptionalRequired) {
+		return false
+	}
+
+	if !g.CustomType.Equal(h.CustomType) {
+		return false
+	}
+
+	if !g.DeprecationMessage.Equal(h.DeprecationMessage) {
+		return false
+	}
+
+	if !g.Description.Equal(h.Description) {
+		return false
+	}
+
+	if !g.Sensitive.Equal(h.Sensitive) {
+		return false
+	}
+
+	return g.Validators.Equal(h.Validators)
+}
+
+func (g GeneratorInt32Attribute) Schema(name schema.FrameworkIdentifier) (string, error) {
+	var b bytes.Buffer
+
+	b.WriteString(fmt.Sprintf("%q: schema.Int32Attribute{\n", name))
+	b.Write(g.CustomType.Schema())
+	b.Write(g.ComputedOptionalRequired.Schema())
+	b.Write(g.Sensitive.Schema())
+	b.Write(g.Description.Schema())
+	b.Write(g.DeprecationMessage.Schema())
+	b.Write(g.Validators.Schema())
+	b.WriteString("},")
+
+	return b.String(), nil
+}
+
+func (g GeneratorInt32Attribute) ModelField(name schema.FrameworkIdentifier) (model.Field, error) {
+	field := model.Field{
+		Name:      name.ToPascalCase(),
+		TfsdkName: name.ToString(),
+		ValueType: model.Int32ValueType,
+	}
+
+	customValueType := g.CustomType.ValueType()
+
+	if customValueType != "" {
+		field.ValueType = customValueType
+	}
+
+	return field, nil
+}
+
+func (g GeneratorInt32Attribute) CustomTypeAndValue(name string) ([]byte, error) {
+	if g.AssociatedExternalType == nil {
+		return nil, nil
+	}
+
+	var buf bytes.Buffer
+
+	int32Type := schema.NewCustomInt32Type(name)
+
+	b, err := int32Type.Render()
+
+	if err != nil {
+		return nil, err
+	}
+
+	buf.Write(b)
+
+	int32Value := schema.NewCustomInt32Value(name)
+
+	b, err = int32Value.Render()
+
+	if err != nil {
+		return nil, err
+	}
+
+	buf.Write(b)
+
+	return buf.Bytes(), nil
+}
+
+func (g GeneratorInt32Attribute) ToFromFunctions(name string) ([]byte, error) {
+	if g.AssociatedExternalType == nil {
+		return nil, nil
+	}
+
+	toFrom := schema.NewToFromInt32(name, g.AssociatedExternalType)
+
+	b, err := toFrom.Render()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// AttrType returns a string representation of a basetypes.Int32Typable type.
+func (g GeneratorInt32Attribute) AttrType(name schema.FrameworkIdentifier) (string, error) {
+	if g.AssociatedExternalType != nil {
+		return fmt.Sprintf("%sType{}", name.ToPascalCase()), nil
+	}
+
+	return "basetypes.Int32Type{}", nil
+}
+
+// AttrValue returns a string representation of a basetypes.Int32Valuable type.
+func (g GeneratorInt32Attribute) AttrValue(name schema.FrameworkIdentifier) string {
+	if g.AssociatedExternalType != nil {
+		return fmt.Sprintf("%sValue", name.ToPascalCase())
+	}
+
+	return "basetypes.Int32Value"
+}
+
+func (g GeneratorInt32Attribute) To() (schema.ToFromConversion, error) {
+	if g.AssociatedExternalType != nil {
+		return schema.ToFromConversion{
+			AssocExtType: g.AssociatedExternalType,
+		}, nil
+	}
+
+	return schema.ToFromConversion{
+		Default: "ValueInt32Pointer",
+	}, nil
+}
+
+func (g GeneratorInt32Attribute) From() (schema.ToFromConversion, error) {
+	if g.AssociatedExternalType != nil {
+		return schema.ToFromConversion{
+			AssocExtType: g.AssociatedExternalType,
+		}, nil
+	}
+
+	return schema.ToFromConversion{
+		Default: "Int32PointerValue",
+	}, nil
+}

--- a/internal/datasource/int64_attribute.go
+++ b/internal/datasource/int64_attribute.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/int64_attribute_test.go
+++ b/internal/datasource/int64_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/list_attribute.go
+++ b/internal/datasource/list_attribute.go
@@ -7,8 +7,8 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/list_attribute_test.go
+++ b/internal/datasource/list_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/list_nested_attribute.go
+++ b/internal/datasource/list_nested_attribute.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/list_nested_attribute_test.go
+++ b/internal/datasource/list_nested_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/list_nested_block.go
+++ b/internal/datasource/list_nested_block.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/list_nested_block_test.go
+++ b/internal/datasource/list_nested_block_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/map_attribute.go
+++ b/internal/datasource/map_attribute.go
@@ -7,8 +7,8 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/map_attribute_test.go
+++ b/internal/datasource/map_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/map_nested_attribute.go
+++ b/internal/datasource/map_nested_attribute.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/map_nested_attribute_test.go
+++ b/internal/datasource/map_nested_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/number_attribute.go
+++ b/internal/datasource/number_attribute.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/number_attribute_test.go
+++ b/internal/datasource/number_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/object_attribute.go
+++ b/internal/datasource/object_attribute.go
@@ -7,9 +7,9 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/object_attribute_test.go
+++ b/internal/datasource/object_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/schemas_test.go
+++ b/internal/datasource/schemas_test.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"testing"
 
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"

--- a/internal/datasource/set_attribute.go
+++ b/internal/datasource/set_attribute.go
@@ -7,8 +7,8 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/set_attribute_test.go
+++ b/internal/datasource/set_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/set_nested_attribute.go
+++ b/internal/datasource/set_nested_attribute.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/set_nested_attribute_test.go
+++ b/internal/datasource/set_nested_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/set_nested_block.go
+++ b/internal/datasource/set_nested_block.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/set_nested_block_test.go
+++ b/internal/datasource/set_nested_block_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/single_nested_attribute.go
+++ b/internal/datasource/single_nested_attribute.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/single_nested_attribute_test.go
+++ b/internal/datasource/single_nested_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/single_nested_block.go
+++ b/internal/datasource/single_nested_block.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/single_nested_block_test.go
+++ b/internal/datasource/single_nested_block_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/string_attribute.go
+++ b/internal/datasource/string_attribute.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/string_attribute_test.go
+++ b/internal/datasource/string_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/datasource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/datasource/types.go
+++ b/internal/datasource/types.go
@@ -4,7 +4,7 @@
 package datasource
 
 import (
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"
 )

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -12,6 +12,7 @@ const (
 	BoolValueType    = "types.Bool"
 	Float64ValueType = "types.Float64"
 	Int64ValueType   = "types.Int64"
+	Int32ValueType   = "types.Int32"
 	ListValueType    = "types.List"
 	MapValueType     = "types.Map"
 	NumberValueType  = "types.Number"

--- a/internal/ncloud/convert.go
+++ b/internal/ncloud/convert.go
@@ -35,6 +35,12 @@ func Gen_ConvertOAStoTFTypes(data resource.Attributes) (string, string, error) {
 				dto.%[1]s = types.Int64Value(data["%[2]s"].(int64))
 			}`, util.ToPascalCase(n), PascalToSnakeCase(n)) + "\n"
 			m = m + fmt.Sprintf("%[1]s         types.Int64 `tfsdk:\"%[2]s\"`", util.ToPascalCase(n), PascalToSnakeCase(n)) + "\n"
+		} else if val.Float64 != nil || val.Float32 != nil {
+			s = s + fmt.Sprintf(`
+			if data["%[2]s"] != nil {
+				dto.%[1]s = types.Float64Value(data["%[2]s"].(float64))
+			}`, util.ToPascalCase(n), PascalToSnakeCase(n)) + "\n"
+			m = m + fmt.Sprintf("%[1]s         types.Float64 `tfsdk:\"%[2]s\"`", util.ToPascalCase(n), PascalToSnakeCase(n)) + "\n"
 		} else if val.List != nil {
 			if val.List.ElementType.String != nil {
 				s = s + fmt.Sprintf(`"%[1]s": types.ListType{ElemType: types.StringType},`, n) + "\n"

--- a/internal/ncloud/convert.go
+++ b/internal/ncloud/convert.go
@@ -29,6 +29,12 @@ func Gen_ConvertOAStoTFTypes(data resource.Attributes) (string, string, error) {
 				dto.%[1]s = types.BoolValue(data["%[2]s"].(bool))
 			}`, util.ToPascalCase(n), PascalToSnakeCase(n)) + "\n"
 			m = m + fmt.Sprintf("%[1]s         types.Bool `tfsdk:\"%[2]s\"`", util.ToPascalCase(n), PascalToSnakeCase(n)) + "\n"
+		} else if val.Int32 != nil {
+			s = s + fmt.Sprintf(`
+			if data["%[2]s"] != nil {
+				dto.%[1]s = types.Int32Value(data["%[2]s"].(int32))
+			}`, util.ToPascalCase(n), PascalToSnakeCase(n)) + "\n"
+			m = m + fmt.Sprintf("%[1]s         types.Int32 `tfsdk:\"%[2]s\"`", util.ToPascalCase(n), PascalToSnakeCase(n)) + "\n"
 		} else if val.Int64 != nil {
 			s = s + fmt.Sprintf(`
 			if data["%[2]s"] != nil {

--- a/internal/provider/bool_attribute.go
+++ b/internal/provider/bool_attribute.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/bool_attribute_test.go
+++ b/internal/provider/bool_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/convert.go
+++ b/internal/provider/convert.go
@@ -6,8 +6,8 @@ package provider
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/spec"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/spec"
 
 	generatorschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"
 )
@@ -93,6 +93,8 @@ func NewAttribute(a provider.Attribute) (generatorschema.GeneratorAttribute, err
 		return NewGeneratorFloat64Attribute(a.Name, a.Float64)
 	case a.Int64 != nil:
 		return NewGeneratorInt64Attribute(a.Name, a.Int64)
+	case a.Int32 != nil:
+		return NewGeneratorInt32Attribute(a.Name, a.Int32)
 	case a.List != nil:
 		return NewGeneratorListAttribute(a.Name, a.List)
 	case a.ListNested != nil:

--- a/internal/provider/convert_test.go
+++ b/internal/provider/convert_test.go
@@ -6,10 +6,10 @@ package provider
 import (
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/spec"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/spec"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	generatorschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"

--- a/internal/provider/float64_attribute.go
+++ b/internal/provider/float64_attribute.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/float64_attribute_test.go
+++ b/internal/provider/float64_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/int32_attribute.go
+++ b/internal/provider/int32_attribute.go
@@ -1,0 +1,226 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
+
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"
+)
+
+type GeneratorInt32Attribute struct {
+	AssociatedExternalType *schema.AssocExtType
+	OptionalRequired       convert.OptionalRequired
+	CustomType             convert.CustomTypePrimitive
+	DeprecationMessage     convert.DeprecationMessage
+	Description            convert.Description
+	Sensitive              convert.Sensitive
+	Validators             convert.Validators
+}
+
+func NewGeneratorInt32Attribute(name string, a *provider.Int32Attribute) (GeneratorInt32Attribute, error) {
+	if a == nil {
+		return GeneratorInt32Attribute{}, fmt.Errorf("*provider.Int32Attribute is nil")
+	}
+
+	c := convert.NewOptionalRequired(a.OptionalRequired)
+
+	ctp := convert.NewCustomTypePrimitive(a.CustomType, a.AssociatedExternalType, name)
+
+	d := convert.NewDescription(a.Description)
+
+	dm := convert.NewDeprecationMessage(a.DeprecationMessage)
+
+	s := convert.NewSensitive(a.Sensitive)
+
+	v := convert.NewValidators(convert.ValidatorTypeInt32, a.Validators.CustomValidators())
+
+	return GeneratorInt32Attribute{
+		AssociatedExternalType: schema.NewAssocExtType(a.AssociatedExternalType),
+		OptionalRequired:       c,
+		CustomType:             ctp,
+		DeprecationMessage:     dm,
+		Description:            d,
+		Sensitive:              s,
+		Validators:             v,
+	}, nil
+}
+
+func (g GeneratorInt32Attribute) GeneratorSchemaType() schema.Type {
+	return schema.GeneratorInt32Attribute
+}
+
+func (g GeneratorInt32Attribute) Imports() *schema.Imports {
+	imports := schema.NewImports()
+
+	imports.Append(g.CustomType.Imports())
+
+	imports.Append(g.Validators.Imports())
+
+	if g.AssociatedExternalType != nil {
+		imports.Append(schema.AssociatedExternalTypeImports())
+	}
+
+	imports.Append(g.AssociatedExternalType.Imports())
+
+	return imports
+}
+
+func (g GeneratorInt32Attribute) Equal(ga schema.GeneratorAttribute) bool {
+	h, ok := ga.(GeneratorInt32Attribute)
+
+	if !ok {
+		return false
+	}
+
+	if !g.AssociatedExternalType.Equal(h.AssociatedExternalType) {
+		return false
+	}
+
+	if !g.OptionalRequired.Equal(h.OptionalRequired) {
+		return false
+	}
+
+	if !g.CustomType.Equal(h.CustomType) {
+		return false
+	}
+
+	if !g.DeprecationMessage.Equal(h.DeprecationMessage) {
+		return false
+	}
+
+	if !g.Description.Equal(h.Description) {
+		return false
+	}
+
+	if !g.Sensitive.Equal(h.Sensitive) {
+		return false
+	}
+
+	return g.Validators.Equal(h.Validators)
+}
+
+func (g GeneratorInt32Attribute) Schema(name schema.FrameworkIdentifier) (string, error) {
+	var b bytes.Buffer
+
+	b.WriteString(fmt.Sprintf("%q: schema.Int32Attribute{\n", name))
+	b.Write(g.CustomType.Schema())
+	b.Write(g.OptionalRequired.Schema())
+	b.Write(g.Sensitive.Schema())
+	b.Write(g.Description.Schema())
+	b.Write(g.DeprecationMessage.Schema())
+	b.Write(g.Validators.Schema())
+	b.WriteString("},")
+
+	return b.String(), nil
+}
+
+func (g GeneratorInt32Attribute) ModelField(name schema.FrameworkIdentifier) (model.Field, error) {
+	field := model.Field{
+		Name:      name.ToPascalCase(),
+		TfsdkName: name.ToString(),
+		ValueType: model.Int32ValueType,
+	}
+
+	customValueType := g.CustomType.ValueType()
+
+	if customValueType != "" {
+		field.ValueType = customValueType
+	}
+
+	return field, nil
+}
+
+func (g GeneratorInt32Attribute) CustomTypeAndValue(name string) ([]byte, error) {
+	if g.AssociatedExternalType == nil {
+		return nil, nil
+	}
+
+	var buf bytes.Buffer
+
+	int32Type := schema.NewCustomInt32Type(name)
+
+	b, err := int32Type.Render()
+
+	if err != nil {
+		return nil, err
+	}
+
+	buf.Write(b)
+
+	int32Value := schema.NewCustomInt32Value(name)
+
+	b, err = int32Value.Render()
+
+	if err != nil {
+		return nil, err
+	}
+
+	buf.Write(b)
+
+	return buf.Bytes(), nil
+}
+
+func (g GeneratorInt32Attribute) ToFromFunctions(name string) ([]byte, error) {
+	if g.AssociatedExternalType == nil {
+		return nil, nil
+	}
+
+	toFrom := schema.NewToFromInt32(name, g.AssociatedExternalType)
+
+	b, err := toFrom.Render()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// AttrType returns a string representation of a basetypes.Int32Typable type.
+func (g GeneratorInt32Attribute) AttrType(name schema.FrameworkIdentifier) (string, error) {
+	if g.AssociatedExternalType != nil {
+		return fmt.Sprintf("%sType{}", name.ToPascalCase()), nil
+	}
+
+	return "basetypes.Int32Type{}", nil
+}
+
+// AttrValue returns a string representation of a basetypes.Int32Valuable type.
+func (g GeneratorInt32Attribute) AttrValue(name schema.FrameworkIdentifier) string {
+	if g.AssociatedExternalType != nil {
+		return fmt.Sprintf("%sValue", name.ToPascalCase())
+	}
+
+	return "basetypes.Int32Value"
+}
+
+func (g GeneratorInt32Attribute) To() (schema.ToFromConversion, error) {
+	if g.AssociatedExternalType != nil {
+		return schema.ToFromConversion{
+			AssocExtType: g.AssociatedExternalType,
+		}, nil
+	}
+
+	return schema.ToFromConversion{
+		Default: "ValueInt32Pointer",
+	}, nil
+}
+
+func (g GeneratorInt32Attribute) From() (schema.ToFromConversion, error) {
+	if g.AssociatedExternalType != nil {
+		return schema.ToFromConversion{
+			AssocExtType: g.AssociatedExternalType,
+		}, nil
+	}
+
+	return schema.ToFromConversion{
+		Default: "Int32PointerValue",
+	}, nil
+}

--- a/internal/provider/int64_attribute.go
+++ b/internal/provider/int64_attribute.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/int64_attribute_test.go
+++ b/internal/provider/int64_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/list_attribute.go
+++ b/internal/provider/list_attribute.go
@@ -7,8 +7,8 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/list_attribute_test.go
+++ b/internal/provider/list_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/list_nested_attribute.go
+++ b/internal/provider/list_nested_attribute.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/list_nested_attribute_test.go
+++ b/internal/provider/list_nested_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/list_nested_block.go
+++ b/internal/provider/list_nested_block.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/list_nested_block_test.go
+++ b/internal/provider/list_nested_block_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/map_attribute.go
+++ b/internal/provider/map_attribute.go
@@ -7,8 +7,8 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/map_attribute_test.go
+++ b/internal/provider/map_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/map_nested_attribute.go
+++ b/internal/provider/map_nested_attribute.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/map_nested_attribute_test.go
+++ b/internal/provider/map_nested_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/number_attribute.go
+++ b/internal/provider/number_attribute.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/number_attribute_test.go
+++ b/internal/provider/number_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/object_attribute.go
+++ b/internal/provider/object_attribute.go
@@ -7,9 +7,9 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/object_attribute_test.go
+++ b/internal/provider/object_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/schemas_test.go
+++ b/internal/provider/schemas_test.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"testing"
 
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"

--- a/internal/provider/set_attribute.go
+++ b/internal/provider/set_attribute.go
@@ -7,8 +7,8 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/set_attribute_test.go
+++ b/internal/provider/set_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/set_nested_attribute.go
+++ b/internal/provider/set_nested_attribute.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/set_nested_attribute_test.go
+++ b/internal/provider/set_nested_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/set_nested_block.go
+++ b/internal/provider/set_nested_block.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/set_nested_block_test.go
+++ b/internal/provider/set_nested_block_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/single_nested_attribute.go
+++ b/internal/provider/single_nested_attribute.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/single_nested_attribute_test.go
+++ b/internal/provider/single_nested_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/single_nested_block.go
+++ b/internal/provider/single_nested_block.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/single_nested_block_test.go
+++ b/internal/provider/single_nested_block_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/string_attribute.go
+++ b/internal/provider/string_attribute.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/string_attribute_test.go
+++ b/internal/provider/string_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/provider"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -4,7 +4,7 @@
 package provider
 
 import (
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"
 )

--- a/internal/resource/bool_attribute.go
+++ b/internal/resource/bool_attribute.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/bool_attribute_test.go
+++ b/internal/resource/bool_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/convert.go
+++ b/internal/resource/convert.go
@@ -6,8 +6,8 @@ package resource
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/spec"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/spec"
 
 	generatorschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"
 )
@@ -90,6 +90,8 @@ func NewAttribute(a resource.Attribute) (generatorschema.GeneratorAttribute, err
 		return NewGeneratorFloat64Attribute(a.Name, a.Float64)
 	case a.Int64 != nil:
 		return NewGeneratorInt64Attribute(a.Name, a.Int64)
+	case a.Int32 != nil:
+		return NewGeneratorInt32Attribute(a.Name, a.Int32)
 	case a.List != nil:
 		return NewGeneratorListAttribute(a.Name, a.List)
 	case a.ListNested != nil:

--- a/internal/resource/convert_test.go
+++ b/internal/resource/convert_test.go
@@ -6,10 +6,10 @@ package resource
 import (
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/spec"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/spec"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	generatorschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"

--- a/internal/resource/float64_attribute.go
+++ b/internal/resource/float64_attribute.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/float64_attribute_test.go
+++ b/internal/resource/float64_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/int32_attribute.go
+++ b/internal/resource/int32_attribute.go
@@ -1,0 +1,248 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resource
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
+
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"
+	generatorschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"
+)
+
+type GeneratorInt32Attribute struct {
+	AssociatedExternalType   *generatorschema.AssocExtType
+	ComputedOptionalRequired convert.ComputedOptionalRequired
+	CustomType               convert.CustomTypePrimitive
+	Default                  convert.DefaultInt32
+	DeprecationMessage       convert.DeprecationMessage
+	Description              convert.Description
+	PlanModifiers            convert.PlanModifiers
+	Sensitive                convert.Sensitive
+	Validators               convert.Validators
+}
+
+func NewGeneratorInt32Attribute(name string, a *resource.Int32Attribute) (GeneratorInt32Attribute, error) {
+	if a == nil {
+		return GeneratorInt32Attribute{}, fmt.Errorf("*resource.Int32Attribute is nil")
+	}
+
+	c := convert.NewComputedOptionalRequired(a.ComputedOptionalRequired)
+
+	ctp := convert.NewCustomTypePrimitive(a.CustomType, a.AssociatedExternalType, name)
+
+	di := convert.NewDefaultInt32(a.Default)
+
+	dm := convert.NewDeprecationMessage(a.DeprecationMessage)
+
+	d := convert.NewDescription(a.Description)
+
+	pm := convert.NewPlanModifiers(convert.PlanModifierTypeInt32, a.PlanModifiers.CustomPlanModifiers())
+
+	s := convert.NewSensitive(a.Sensitive)
+
+	v := convert.NewValidators(convert.ValidatorTypeInt32, a.Validators.CustomValidators())
+
+	return GeneratorInt32Attribute{
+		AssociatedExternalType:   generatorschema.NewAssocExtType(a.AssociatedExternalType),
+		ComputedOptionalRequired: c,
+		CustomType:               ctp,
+		Default:                  di,
+		DeprecationMessage:       dm,
+		Description:              d,
+		PlanModifiers:            pm,
+		Sensitive:                s,
+		Validators:               v,
+	}, nil
+}
+
+func (g GeneratorInt32Attribute) GeneratorSchemaType() generatorschema.Type {
+	return generatorschema.GeneratorInt32Attribute
+}
+
+func (g GeneratorInt32Attribute) Imports() *generatorschema.Imports {
+	imports := generatorschema.NewImports()
+
+	imports.Append(g.CustomType.Imports())
+
+	imports.Append(g.Default.Imports())
+
+	imports.Append(g.PlanModifiers.Imports())
+
+	imports.Append(g.Validators.Imports())
+
+	if g.AssociatedExternalType != nil {
+		imports.Append(generatorschema.AssociatedExternalTypeImports())
+	}
+
+	imports.Append(g.AssociatedExternalType.Imports())
+
+	return imports
+}
+
+func (g GeneratorInt32Attribute) Equal(ga generatorschema.GeneratorAttribute) bool {
+	h, ok := ga.(GeneratorInt32Attribute)
+
+	if !ok {
+		return false
+	}
+
+	if !g.AssociatedExternalType.Equal(h.AssociatedExternalType) {
+		return false
+	}
+
+	if !g.ComputedOptionalRequired.Equal(h.ComputedOptionalRequired) {
+		return false
+	}
+
+	if !g.CustomType.Equal(h.CustomType) {
+		return false
+	}
+
+	if !g.Default.Equal(h.Default) {
+		return false
+	}
+
+	if !g.DeprecationMessage.Equal(h.DeprecationMessage) {
+		return false
+	}
+
+	if !g.Description.Equal(h.Description) {
+		return false
+	}
+
+	if !g.PlanModifiers.Equal(h.PlanModifiers) {
+		return false
+	}
+
+	if !g.Sensitive.Equal(h.Sensitive) {
+		return false
+	}
+
+	return g.Validators.Equal(h.Validators)
+}
+
+func (g GeneratorInt32Attribute) Schema(name generatorschema.FrameworkIdentifier) (string, error) {
+	var b bytes.Buffer
+
+	b.WriteString(fmt.Sprintf("%q: schema.Int32Attribute{\n", name))
+	b.Write(g.CustomType.Schema())
+	b.Write(g.ComputedOptionalRequired.Schema())
+	b.Write(g.Sensitive.Schema())
+	b.Write(g.Description.Schema())
+	b.Write(g.DeprecationMessage.Schema())
+	b.Write(g.PlanModifiers.Schema())
+	b.Write(g.Validators.Schema())
+	b.Write(g.Default.Schema())
+	b.WriteString("},")
+
+	return b.String(), nil
+}
+
+func (g GeneratorInt32Attribute) ModelField(name generatorschema.FrameworkIdentifier) (model.Field, error) {
+	field := model.Field{
+		Name:      name.ToPascalCase(),
+		TfsdkName: name.ToString(),
+		ValueType: model.Int32ValueType,
+	}
+
+	customValueType := g.CustomType.ValueType()
+
+	if customValueType != "" {
+		field.ValueType = customValueType
+	}
+
+	return field, nil
+}
+
+func (g GeneratorInt32Attribute) CustomTypeAndValue(name string) ([]byte, error) {
+	if g.AssociatedExternalType == nil {
+		return nil, nil
+	}
+
+	var buf bytes.Buffer
+
+	int32Type := generatorschema.NewCustomInt32Type(name)
+
+	b, err := int32Type.Render()
+
+	if err != nil {
+		return nil, err
+	}
+
+	buf.Write(b)
+
+	int32Value := generatorschema.NewCustomInt32Value(name)
+
+	b, err = int32Value.Render()
+
+	if err != nil {
+		return nil, err
+	}
+
+	buf.Write(b)
+
+	return buf.Bytes(), nil
+}
+
+func (g GeneratorInt32Attribute) ToFromFunctions(name string) ([]byte, error) {
+	if g.AssociatedExternalType == nil {
+		return nil, nil
+	}
+
+	toFrom := generatorschema.NewToFromInt32(name, g.AssociatedExternalType)
+
+	b, err := toFrom.Render()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// AttrType returns a string representation of a basetypes.Int32Typable type.
+func (g GeneratorInt32Attribute) AttrType(name generatorschema.FrameworkIdentifier) (string, error) {
+	if g.AssociatedExternalType != nil {
+		return fmt.Sprintf("%sType{}", name.ToPascalCase()), nil
+	}
+
+	return "basetypes.Int32Type{}", nil
+}
+
+// AttrValue returns a string representation of a basetypes.Int32Valuable type.
+func (g GeneratorInt32Attribute) AttrValue(name generatorschema.FrameworkIdentifier) string {
+	if g.AssociatedExternalType != nil {
+		return fmt.Sprintf("%sValue", name.ToPascalCase())
+	}
+
+	return "basetypes.Int32Value"
+}
+
+func (g GeneratorInt32Attribute) To() (generatorschema.ToFromConversion, error) {
+	if g.AssociatedExternalType != nil {
+		return generatorschema.ToFromConversion{
+			AssocExtType: g.AssociatedExternalType,
+		}, nil
+	}
+
+	return generatorschema.ToFromConversion{
+		Default: "ValueInt32Pointer",
+	}, nil
+}
+
+func (g GeneratorInt32Attribute) From() (generatorschema.ToFromConversion, error) {
+	if g.AssociatedExternalType != nil {
+		return generatorschema.ToFromConversion{
+			AssocExtType: g.AssociatedExternalType,
+		}, nil
+	}
+
+	return generatorschema.ToFromConversion{
+		Default: "Int32PointerValue",
+	}, nil
+}

--- a/internal/resource/int64_attribute.go
+++ b/internal/resource/int64_attribute.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/int64_attribute_test.go
+++ b/internal/resource/int64_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/list_attribute.go
+++ b/internal/resource/list_attribute.go
@@ -7,8 +7,8 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/list_attribute_test.go
+++ b/internal/resource/list_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/list_nested_attribute.go
+++ b/internal/resource/list_nested_attribute.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/list_nested_attribute_test.go
+++ b/internal/resource/list_nested_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/list_nested_block.go
+++ b/internal/resource/list_nested_block.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/list_nested_block_test.go
+++ b/internal/resource/list_nested_block_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/map_attribute.go
+++ b/internal/resource/map_attribute.go
@@ -7,8 +7,8 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/map_attribute_test.go
+++ b/internal/resource/map_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/map_nested_attribute.go
+++ b/internal/resource/map_nested_attribute.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/map_nested_attribute_test.go
+++ b/internal/resource/map_nested_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/nested_attribute_object.go
+++ b/internal/resource/nested_attribute_object.go
@@ -6,7 +6,7 @@ package resource
 import (
 	"bytes"
 
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	generatorschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"

--- a/internal/resource/nested_block_object.go
+++ b/internal/resource/nested_block_object.go
@@ -6,7 +6,7 @@ package resource
 import (
 	"bytes"
 
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	generatorschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"

--- a/internal/resource/number_attribute.go
+++ b/internal/resource/number_attribute.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/number_attribute_test.go
+++ b/internal/resource/number_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/object_attribute.go
+++ b/internal/resource/object_attribute.go
@@ -7,9 +7,9 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/object_attribute_test.go
+++ b/internal/resource/object_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/schemas_test.go
+++ b/internal/resource/schemas_test.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	generatorschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"

--- a/internal/resource/set_attribute.go
+++ b/internal/resource/set_attribute.go
@@ -7,8 +7,8 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/set_attribute_test.go
+++ b/internal/resource/set_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/set_nested_attribute.go
+++ b/internal/resource/set_nested_attribute.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/set_nested_attribute_test.go
+++ b/internal/resource/set_nested_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/set_nested_block.go
+++ b/internal/resource/set_nested_block.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/set_nested_block_test.go
+++ b/internal/resource/set_nested_block_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/single_nested_attribute.go
+++ b/internal/resource/single_nested_attribute.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/single_nested_attribute_test.go
+++ b/internal/resource/single_nested_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/single_nested_block.go
+++ b/internal/resource/single_nested_block.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/single_nested_block_test.go
+++ b/internal/resource/single_nested_block_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/string_attribute.go
+++ b/internal/resource/string_attribute.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/string_attribute_test.go
+++ b/internal/resource/string_attribute_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/resource"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/convert"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/resource/types.go
+++ b/internal/resource/types.go
@@ -4,7 +4,7 @@
 package resource
 
 import (
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/schema"
 )

--- a/internal/schema/associated_external_type.go
+++ b/internal/schema/associated_external_type.go
@@ -8,8 +8,8 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 )
 
 type AssocExtType struct {

--- a/internal/schema/attrtypes.go
+++ b/internal/schema/attrtypes.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"strings"
 
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 )
 
 // GetAttrTypes generates the strings for use within templates for specifying the types to use with

--- a/internal/schema/custom_int32.go
+++ b/internal/schema/custom_int32.go
@@ -1,0 +1,345 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"bytes"
+	"text/template"
+)
+
+type CustomInt32Type struct {
+	Name      FrameworkIdentifier
+	templates map[string]string
+}
+
+func NewCustomInt32Type(name string) CustomInt32Type {
+	t := map[string]string{
+		"equal":              Int32TypeEqualTemplate,
+		"string":             Int32TypeStringTemplate,
+		"type":               Int32TypeTypeTemplate,
+		"typable":            Int32TypeTypableTemplate,
+		"valueFromInt32":     Int32TypeValueFromInt32Template,
+		"valueFromTerraform": Int32TypeValueFromTerraformTemplate,
+		"valueType":          Int32TypeValueTypeTemplate,
+	}
+
+	return CustomInt32Type{
+		Name:      FrameworkIdentifier(name),
+		templates: t,
+	}
+}
+
+func (c CustomInt32Type) Render() ([]byte, error) {
+	var buf bytes.Buffer
+
+	renderFuncs := []func() ([]byte, error){
+		c.renderTypable,
+		c.renderType,
+		c.renderEqual,
+		c.renderString,
+		c.renderValueFromInt32,
+		c.renderValueFromTerraform,
+		c.renderValueType,
+	}
+
+	for _, f := range renderFuncs {
+		b, err := f()
+
+		if err != nil {
+			return nil, err
+		}
+
+		buf.Write([]byte("\n"))
+
+		buf.Write(b)
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (c CustomInt32Type) renderEqual() ([]byte, error) {
+	var buf bytes.Buffer
+
+	t, err := template.New("").Parse(c.templates["equal"])
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = t.Execute(&buf, struct {
+		Name string
+	}{
+		Name: c.Name.ToPascalCase(),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (c CustomInt32Type) renderString() ([]byte, error) {
+	var buf bytes.Buffer
+
+	t, err := template.New("").Parse(c.templates["string"])
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = t.Execute(&buf, struct {
+		Name string
+	}{
+		Name: c.Name.ToPascalCase(),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (c CustomInt32Type) renderType() ([]byte, error) {
+	var buf bytes.Buffer
+
+	t, err := template.New("").Parse(c.templates["type"])
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = t.Execute(&buf, struct {
+		Name string
+	}{
+		Name: c.Name.ToPascalCase(),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (c CustomInt32Type) renderTypable() ([]byte, error) {
+	var buf bytes.Buffer
+
+	t, err := template.New("").Parse(c.templates["typable"])
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = t.Execute(&buf, struct {
+		Name string
+	}{
+		Name: c.Name.ToPascalCase(),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (c CustomInt32Type) renderValueFromInt32() ([]byte, error) {
+	var buf bytes.Buffer
+
+	t, err := template.New("").Parse(c.templates["valueFromInt32"])
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = t.Execute(&buf, struct {
+		Name string
+	}{
+		Name: c.Name.ToPascalCase(),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (c CustomInt32Type) renderValueFromTerraform() ([]byte, error) {
+	var buf bytes.Buffer
+
+	t, err := template.New("").Parse(c.templates["valueFromTerraform"])
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = t.Execute(&buf, struct {
+		Name string
+	}{
+		Name: c.Name.ToPascalCase(),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (c CustomInt32Type) renderValueType() ([]byte, error) {
+	var buf bytes.Buffer
+
+	t, err := template.New("").Parse(c.templates["valueType"])
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = t.Execute(&buf, struct {
+		Name string
+	}{
+		Name: c.Name.ToPascalCase(),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+type CustomInt32Value struct {
+	Name      FrameworkIdentifier
+	templates map[string]string
+}
+
+func NewCustomInt32Value(name string) CustomInt32Value {
+	t := map[string]string{
+		"equal":    Int32ValueEqualTemplate,
+		"type":     Int32ValueTypeTemplate,
+		"valuable": Int32ValueValuableTemplate,
+		"value":    Int32ValueValueTemplate,
+	}
+
+	return CustomInt32Value{
+		Name:      FrameworkIdentifier(name),
+		templates: t,
+	}
+}
+
+func (c CustomInt32Value) Render() ([]byte, error) {
+	var buf bytes.Buffer
+
+	renderFuncs := []func() ([]byte, error){
+		c.renderValuable,
+		c.renderValue,
+		c.renderEqual,
+		c.renderType,
+	}
+
+	for _, f := range renderFuncs {
+		b, err := f()
+
+		if err != nil {
+			return nil, err
+		}
+
+		buf.Write([]byte("\n"))
+
+		buf.Write(b)
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (c CustomInt32Value) renderEqual() ([]byte, error) {
+	var buf bytes.Buffer
+
+	t, err := template.New("").Parse(c.templates["equal"])
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = t.Execute(&buf, struct {
+		Name string
+	}{
+		Name: c.Name.ToPascalCase(),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (c CustomInt32Value) renderType() ([]byte, error) {
+	var buf bytes.Buffer
+
+	t, err := template.New("").Parse(c.templates["type"])
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = t.Execute(&buf, struct {
+		Name string
+	}{
+		Name: c.Name.ToPascalCase(),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (c CustomInt32Value) renderValuable() ([]byte, error) {
+	var buf bytes.Buffer
+
+	t, err := template.New("").Parse(c.templates["valuable"])
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = t.Execute(&buf, struct {
+		Name string
+	}{
+		Name: c.Name.ToPascalCase(),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (c CustomInt32Value) renderValue() ([]byte, error) {
+	var buf bytes.Buffer
+
+	t, err := template.New("").Parse(c.templates["value"])
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = t.Execute(&buf, struct {
+		Name string
+	}{
+		Name: c.Name.ToPascalCase(),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}

--- a/internal/schema/elements.go
+++ b/internal/schema/elements.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 )
 
 // GetElementType generates the strings for use within templates for specifying the types to use with

--- a/internal/schema/embed.go
+++ b/internal/schema/embed.go
@@ -97,6 +97,51 @@ var Float64ValueValueTemplate string
 //go:embed templates/float64_value_valuable.gotmpl
 var Float64ValueValuableTemplate string
 
+// Int32 From/To
+
+//go:embed templates/int32_from.gotmpl
+var Int32FromTemplate string
+
+//go:embed templates/int32_to.gotmpl
+var Int32ToTemplate string
+
+// Int32 Type
+
+//go:embed templates/int32_type_equal.gotmpl
+var Int32TypeEqualTemplate string
+
+//go:embed templates/int32_type_string.gotmpl
+var Int32TypeStringTemplate string
+
+//go:embed templates/int32_type_type.gotmpl
+var Int32TypeTypeTemplate string
+
+//go:embed templates/int32_type_typable.gotmpl
+var Int32TypeTypableTemplate string
+
+//go:embed templates/int32_type_value_from_int32.gotmpl
+var Int32TypeValueFromInt32Template string
+
+//go:embed templates/int32_type_value_from_terraform.gotmpl
+var Int32TypeValueFromTerraformTemplate string
+
+//go:embed templates/int32_type_value_type.gotmpl
+var Int32TypeValueTypeTemplate string
+
+// Int32 Value
+
+//go:embed templates/int32_value_equal.gotmpl
+var Int32ValueEqualTemplate string
+
+//go:embed templates/int32_value_type.gotmpl
+var Int32ValueTypeTemplate string
+
+//go:embed templates/int32_value_value.gotmpl
+var Int32ValueValueTemplate string
+
+//go:embed templates/int32_value_valuable.gotmpl
+var Int32ValueValuableTemplate string
+
 // Int64 From/To
 
 //go:embed templates/int64_from.gotmpl

--- a/internal/schema/import.go
+++ b/internal/schema/import.go
@@ -4,7 +4,7 @@
 package schema
 
 import (
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
 )
 
 const (

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/logging"
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"

--- a/internal/schema/templates/int32_from.gotmpl
+++ b/internal/schema/templates/int32_from.gotmpl
@@ -1,0 +1,14 @@
+
+func (v {{.Name}}Value) From{{.AssocExtType.ToPascalCase}}(ctx context.Context, apiObject {{.AssocExtType.Type}}) ({{.Name}}Value, diag.Diagnostics) {
+var diags diag.Diagnostics
+
+if apiObject == nil {
+return {{.Name}}Value{
+types.int32Null(),
+}, diags
+}
+
+return {{.Name}}Value{
+types.int32PointerValue(*apiObject),
+}, diags
+}

--- a/internal/schema/templates/int32_to.gotmpl
+++ b/internal/schema/templates/int32_to.gotmpl
@@ -1,0 +1,20 @@
+func (v {{.Name}}Value) To{{.AssocExtType.ToPascalCase}}(ctx context.Context) ({{.AssocExtType.Type}}, diag.Diagnostics) {
+var diags diag.Diagnostics
+
+if v.IsNull() {
+return nil, diags
+}
+
+if v.IsUnknown() {
+diags.Append(diag.NewErrorDiagnostic(
+"{{.Name}}Value Value Is Unknown",
+`"{{.Name}}Value" is unknown.`,
+))
+
+return nil, diags
+}
+
+a := {{.AssocExtType.TypeReference}}(v.Valueint32Pointer())
+
+return &a, diags
+}

--- a/internal/schema/templates/int32_type_equal.gotmpl
+++ b/internal/schema/templates/int32_type_equal.gotmpl
@@ -1,0 +1,9 @@
+func (t {{.Name}}Type) Equal(o attr.Type) bool {
+other, ok := o.({{.Name}}Type)
+
+if !ok {
+return false
+}
+
+return t.int32Type.Equal(other.int32Type)
+}

--- a/internal/schema/templates/int32_type_string.gotmpl
+++ b/internal/schema/templates/int32_type_string.gotmpl
@@ -1,0 +1,4 @@
+
+func (t {{.Name}}Type) String() string {
+return "{{.Name}}Type"
+}

--- a/internal/schema/templates/int32_type_typable.gotmpl
+++ b/internal/schema/templates/int32_type_typable.gotmpl
@@ -1,0 +1,1 @@
+var _ basetypes.int32Typable = {{.Name}}Type{}

--- a/internal/schema/templates/int32_type_type.gotmpl
+++ b/internal/schema/templates/int32_type_type.gotmpl
@@ -1,0 +1,3 @@
+type {{.Name}}Type struct {
+basetypes.int32Type
+}

--- a/internal/schema/templates/int32_type_value_from_int32.gotmpl
+++ b/internal/schema/templates/int32_type_value_from_int32.gotmpl
@@ -1,0 +1,6 @@
+
+func (t {{.Name}}Type) ValueFromint32(ctx context.Context, in basetypes.int32Value) (basetypes.int32Valuable, diag.Diagnostics) {
+return {{.Name}}Value{
+int32Value: in,
+}, nil
+}

--- a/internal/schema/templates/int32_type_value_from_terraform.gotmpl
+++ b/internal/schema/templates/int32_type_value_from_terraform.gotmpl
@@ -1,0 +1,22 @@
+
+func (t {{.Name}}Type) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+attrValue, err := t.int32Type.ValueFromTerraform(ctx, in)
+
+if err != nil {
+return nil, err
+}
+
+boolValue, ok := attrValue.(basetypes.int32Value)
+
+if !ok {
+return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+}
+
+boolValuable, diags := t.ValueFromint32(ctx, boolValue)
+
+if diags.HasError() {
+return nil, fmt.Errorf("unexpected error converting int32Value to int32Valuable: %v", diags)
+}
+
+return boolValuable, nil
+}

--- a/internal/schema/templates/int32_type_value_type.gotmpl
+++ b/internal/schema/templates/int32_type_value_type.gotmpl
@@ -1,0 +1,4 @@
+
+func (t {{.Name}}Type) ValueType(ctx context.Context) attr.Value {
+return {{.Name}}Value{}
+}

--- a/internal/schema/templates/int32_value_equal.gotmpl
+++ b/internal/schema/templates/int32_value_equal.gotmpl
@@ -1,0 +1,10 @@
+
+func (v {{.Name}}Value) Equal(o attr.Value) bool {
+other, ok := o.({{.Name}}Value)
+
+if !ok {
+return false
+}
+
+return v.int32Value.Equal(other.int32Value)
+}

--- a/internal/schema/templates/int32_value_type.gotmpl
+++ b/internal/schema/templates/int32_value_type.gotmpl
@@ -1,0 +1,5 @@
+
+func (v {{.Name}}Value) Type(ctx context.Context) attr.Type {
+return {{.Name}}Type{
+}
+}

--- a/internal/schema/templates/int32_value_valuable.gotmpl
+++ b/internal/schema/templates/int32_value_valuable.gotmpl
@@ -1,0 +1,1 @@
+var _ basetypes.int32Valuable = {{.Name}}Value{}

--- a/internal/schema/templates/int32_value_value.gotmpl
+++ b/internal/schema/templates/int32_value_value.gotmpl
@@ -1,0 +1,3 @@
+type {{.Name}}Value struct {
+basetypes.int32Value
+}

--- a/internal/schema/to_from_bool_test.go
+++ b/internal/schema/to_from_bool_test.go
@@ -6,9 +6,9 @@ package schema
 import (
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 )
 
 func TestToFromBool_renderFrom(t *testing.T) {

--- a/internal/schema/to_from_float64_test.go
+++ b/internal/schema/to_from_float64_test.go
@@ -6,9 +6,9 @@ package schema
 import (
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 )
 
 func TestToFromFloat64_renderFrom(t *testing.T) {

--- a/internal/schema/to_from_int32.go
+++ b/internal/schema/to_from_int32.go
@@ -1,0 +1,99 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"bytes"
+	"text/template"
+)
+
+type ToFromInt32 struct {
+	Name         FrameworkIdentifier
+	AssocExtType *AssocExtType
+	templates    map[string]string
+}
+
+func NewToFromInt32(name string, assocExtType *AssocExtType) ToFromInt32 {
+	t := map[string]string{
+		"from": Int32FromTemplate,
+		"to":   Int32ToTemplate,
+	}
+
+	return ToFromInt32{
+		Name:         FrameworkIdentifier(name),
+		AssocExtType: assocExtType,
+		templates:    t,
+	}
+}
+
+func (o ToFromInt32) Render() ([]byte, error) {
+	var buf bytes.Buffer
+
+	renderFuncs := []func() ([]byte, error){
+		o.renderTo,
+		o.renderFrom,
+	}
+
+	for _, f := range renderFuncs {
+		b, err := f()
+
+		if err != nil {
+			return nil, err
+		}
+
+		buf.Write([]byte("\n"))
+
+		buf.Write(b)
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (o ToFromInt32) renderTo() ([]byte, error) {
+	var buf bytes.Buffer
+
+	t, err := template.New("").Parse(o.templates["to"])
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = t.Execute(&buf, struct {
+		Name         string
+		AssocExtType *AssocExtType
+	}{
+		Name:         o.Name.ToPascalCase(),
+		AssocExtType: o.AssocExtType,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (o ToFromInt32) renderFrom() ([]byte, error) {
+	var buf bytes.Buffer
+
+	t, err := template.New("").Parse(o.templates["from"])
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = t.Execute(&buf, struct {
+		Name         string
+		AssocExtType *AssocExtType
+	}{
+		Name:         o.Name.ToPascalCase(),
+		AssocExtType: o.AssocExtType,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}

--- a/internal/schema/to_from_int64_test.go
+++ b/internal/schema/to_from_int64_test.go
@@ -6,9 +6,9 @@ package schema
 import (
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 )
 
 func TestToFromInt64_renderFrom(t *testing.T) {

--- a/internal/schema/to_from_list_test.go
+++ b/internal/schema/to_from_list_test.go
@@ -6,9 +6,9 @@ package schema
 import (
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 )
 
 func TestToFromList_renderFrom(t *testing.T) {

--- a/internal/schema/to_from_map_test.go
+++ b/internal/schema/to_from_map_test.go
@@ -6,9 +6,9 @@ package schema
 import (
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 )
 
 func TestToFromMap_renderFrom(t *testing.T) {

--- a/internal/schema/to_from_nested_object_test.go
+++ b/internal/schema/to_from_nested_object_test.go
@@ -6,9 +6,9 @@ package schema
 import (
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 )
 
 func TestToFromNestedObject_renderFrom(t *testing.T) {

--- a/internal/schema/to_from_number_test.go
+++ b/internal/schema/to_from_number_test.go
@@ -6,9 +6,9 @@ package schema
 import (
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 )
 
 func TestToFromNumber_renderFrom(t *testing.T) {

--- a/internal/schema/to_from_object_test.go
+++ b/internal/schema/to_from_object_test.go
@@ -6,9 +6,9 @@ package schema
 import (
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 )
 
 func TestToFromObject_renderFrom(t *testing.T) {

--- a/internal/schema/to_from_set_test.go
+++ b/internal/schema/to_from_set_test.go
@@ -6,9 +6,9 @@ package schema
 import (
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 )
 
 func TestToFromSet_renderFrom(t *testing.T) {

--- a/internal/schema/to_from_string_test.go
+++ b/internal/schema/to_from_string_test.go
@@ -6,9 +6,9 @@ package schema
 import (
 	"testing"
 
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/code"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
-	"github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 )
 
 func TestToFromString_renderFrom(t *testing.T) {

--- a/internal/schema/types.go
+++ b/internal/schema/types.go
@@ -4,7 +4,7 @@
 package schema
 
 import (
-	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+	specschema "github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/schema"
 
 	"github.com/NaverCloudPlatform/terraform-plugin-codegen-framework/internal/model"
 )
@@ -97,6 +97,7 @@ const (
 	GeneratorBoolAttribute
 	GeneratorFloat64Attribute
 	GeneratorInt64Attribute
+	GeneratorInt32Attribute
 	GeneratorListAttribute
 	GeneratorListNestedAttribute
 	GeneratorListNestedBlock


### PR DESCRIPTION
- Changed base module name for streamlined import (and removed hashicorp/terraform-plugin-codegen)
- New files & file changes for additional 32-bit support