### PR TITLE
fix: Fixes an issue where a required attribute is defined as optional, computed

### DIFF
--- a/internal/convert/computed_optional_required.go
+++ b/internal/convert/computed_optional_required.go
@@ -47,8 +47,7 @@ func (c ComputedOptionalRequired) Schema() []byte {
 	var b bytes.Buffer
 
 	if c.IsRequired() {
-		b.WriteString("Computed: true,\n")
-		b.WriteString("Optional: true,\n")
+		b.WriteString("Required: true,\n")
 	}
 
 	if c.IsOptional() {


### PR DESCRIPTION
### Description
- Specification 에 required 로 설정된 attributes 가 Codegen 이후 ncloud provider 에서는 optional, computed 로 속성 정의되고 있음
```json
Specification Config

{
             "name": "product",
             "schema": {
                 "attributes": [
                     {
                         "name": "description",
                         "string": {
                             "computed_optional_required": "computed_optional",
                             "description": "Description\u003cbr\u003eLength(Min/Max): 0/300"
                         }
                     },
                     {
                         "name": "product_name",
                         "string": {
                             "computed_optional_required": "required",
                             "description": "Product Name\u003cbr\u003eLength(Min/Max): 0/100"
                         }
                     },
``` 
```go
terraform-provider-ncloud 의 apigw product 리소스 스키마

"product_name": schema.StringAttribute{
                   Computed:            true,
                   Optional:            true,
                   Description:         "Product Name<br>Length(Min/Max): 0/100",
                   MarkdownDescription: "Product Name<br>Length(Min/Max): 0/100",
               },
```
- required 로 설정된 attributes 는 required 로 설정되도록 수정.